### PR TITLE
Implementar cierre de caja, autorizaciones remotas y auditoría

### DIFF
--- a/binexus-erp/README.md
+++ b/binexus-erp/README.md
@@ -55,6 +55,17 @@ La aplicación quedará disponible en `http://localhost:8080`.
 - Gestión de organizaciones y locales con formularios Thymeleaf responsivos.
 - Layout reutilizable con fragmentos, modo claro/oscuro, toasts y Chart.js en el dashboard.
 - Migraciones Flyway y configuración productiva (`ddl-auto=validate`).
+- Módulo de cierre de caja con historial, aperturas controladas y resumen de ventas.
+- Solicitudes de autorizaciones remotas con aprobación por usuarios administradores y seguimiento de estados.
+- Auditoría automática (`created_at` / `updated_at`) para las principales entidades del dominio.
+
+### Guía rápida: cierre de caja y autorizaciones
+
+1. **Apertura de caja**: navega a `Caja → Abrir` e ingresa el monto inicial. El sistema valida que no exista otra caja abierta para el usuario en curso.
+2. **Registro de ventas**: mientras exista una caja abierta, las ventas quedan asociadas al cierre activo; si no hay caja abierta, el servicio de ventas bloquea la operación.
+3. **Cierre de caja**: desde `Caja → Cerrar` revisa el resumen de ventas y confirma el cierre para almacenar la fecha y calcular las diferencias.
+4. **Historial**: consulta `Caja → Historial` para revisar aperturas y cierres previos ordenados cronológicamente.
+5. **Autorizaciones remotas**: ante acciones restringidas (anular venta, modificar precios, etc.) solicita una autorización y comparte el código generado con un supervisor. Los administradores aprueban o rechazan desde `Autorizaciones`, manteniendo un registro auditable.
 
 ## Pruebas
 
@@ -63,6 +74,8 @@ Ejecuta las pruebas unitarias y de integración con:
 ```bash
 mvn test
 ```
+
+Las pruebas actuales validan las reglas de negocio del cierre de caja y el flujo principal del controlador de autorizaciones remotas.
 
 ## Buenas prácticas de seguridad
 

--- a/binexus-erp/pom.xml
+++ b/binexus-erp/pom.xml
@@ -74,6 +74,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>

--- a/binexus-erp/src/main/java/cl/gob/binexus/config/PersistenceConfig.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/config/PersistenceConfig.java
@@ -1,0 +1,9 @@
+package cl.gob.binexus.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class PersistenceConfig {
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/controller/AutorizacionRemotaController.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/controller/AutorizacionRemotaController.java
@@ -1,0 +1,92 @@
+package cl.gob.binexus.controller;
+
+import cl.gob.binexus.domain.entity.AutorizacionRemota;
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoAutorizacion;
+import cl.gob.binexus.service.AutorizacionRemotaService;
+import cl.gob.binexus.service.CierreCajaService;
+import cl.gob.binexus.service.UsuarioService;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+import java.util.Optional;
+
+@Controller
+@RequestMapping("/autorizaciones")
+public class AutorizacionRemotaController {
+
+    private final AutorizacionRemotaService autorizacionRemotaService;
+    private final CierreCajaService cierreCajaService;
+    private final UsuarioService usuarioService;
+
+    public AutorizacionRemotaController(AutorizacionRemotaService autorizacionRemotaService,
+                                        CierreCajaService cierreCajaService,
+                                        UsuarioService usuarioService) {
+        this.autorizacionRemotaService = autorizacionRemotaService;
+        this.cierreCajaService = cierreCajaService;
+        this.usuarioService = usuarioService;
+    }
+
+    @GetMapping
+    public String listar(@RequestParam(value = "estado", required = false) EstadoAutorizacion estado,
+                         @AuthenticationPrincipal User userDetails,
+                         Model model) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        List<AutorizacionRemota> autorizaciones = autorizacionRemotaService.listarPorEstado(estado);
+        Optional<CierreCaja> caja = cierreCajaService.obtenerCajaAbierta(usuario);
+        model.addAttribute("autorizaciones", autorizaciones);
+        model.addAttribute("estadoSeleccionado", estado);
+        model.addAttribute("estados", EstadoAutorizacion.values());
+        model.addAttribute("caja", caja.orElse(null));
+        model.addAttribute("pageTitle", "Autorizaciones remotas");
+        return "authorizations/autorizaciones-list";
+    }
+
+    @PostMapping
+    public String solicitar(@RequestParam("accion") String accion,
+                            @AuthenticationPrincipal User userDetails,
+                            RedirectAttributes redirectAttributes) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        Optional<CierreCaja> cajaOpt = cierreCajaService.obtenerCajaAbierta(usuario);
+        if (cajaOpt.isEmpty()) {
+            redirectAttributes.addFlashAttribute("toastError", "Debes abrir una caja para solicitar autorizaciones");
+            return "redirect:/autorizaciones";
+        }
+        if (!StringUtils.hasText(accion)) {
+            redirectAttributes.addFlashAttribute("toastError", "La acción es obligatoria");
+            return "redirect:/autorizaciones";
+        }
+        autorizacionRemotaService.solicitar(usuario, cajaOpt.get(), accion);
+        redirectAttributes.addFlashAttribute("toastSuccess", "Autorización solicitada correctamente");
+        return "redirect:/autorizaciones";
+    }
+
+    @PostMapping("/{id}/resolver")
+    public String resolver(@PathVariable("id") Long id,
+                           @RequestParam("estado") EstadoAutorizacion estado,
+                           @AuthenticationPrincipal User userDetails,
+                           RedirectAttributes redirectAttributes) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        try {
+            autorizacionRemotaService.resolver(id, usuario, estado);
+            redirectAttributes.addFlashAttribute("toastSuccess", "Autorización actualizada");
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("toastError", ex.getMessage());
+        }
+        return "redirect:/autorizaciones";
+    }
+
+    private Usuario obtenerUsuario(User userDetails) {
+        if (userDetails == null) {
+            throw new IllegalStateException("No hay usuario autenticado");
+        }
+        return usuarioService.obtenerPorCorreo(userDetails.getUsername());
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/controller/CajaController.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/controller/CajaController.java
@@ -1,0 +1,150 @@
+package cl.gob.binexus.controller;
+
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoCaja;
+import cl.gob.binexus.dto.CierreCajaAperturaForm;
+import cl.gob.binexus.dto.CierreCajaCerrarForm;
+import cl.gob.binexus.dto.CierreCajaResumenDTO;
+import cl.gob.binexus.service.CierreCajaService;
+import cl.gob.binexus.service.UsuarioService;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Controller
+@RequestMapping("/caja")
+public class CajaController {
+
+    private final CierreCajaService cierreCajaService;
+    private final UsuarioService usuarioService;
+
+    public CajaController(CierreCajaService cierreCajaService, UsuarioService usuarioService) {
+        this.cierreCajaService = cierreCajaService;
+        this.usuarioService = usuarioService;
+    }
+
+    @GetMapping("/abrir")
+    public String mostrarApertura(Model model,
+                                  @AuthenticationPrincipal User userDetails,
+                                  RedirectAttributes redirectAttributes) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        Optional<CierreCaja> cajaAbierta = cierreCajaService.obtenerCajaAbierta(usuario);
+        if (cajaAbierta.isPresent()) {
+            redirectAttributes.addFlashAttribute("toastInfo", "Ya tienes una caja abierta");
+            return "redirect:/caja/cerrar";
+        }
+        if (!model.containsAttribute("form")) {
+            model.addAttribute("form", new CierreCajaAperturaForm());
+        }
+        model.addAttribute("pageTitle", "Apertura de caja");
+        return "cashbox/caja-abrir";
+    }
+
+    @PostMapping("/abrir")
+    public String abrirCaja(@Valid @ModelAttribute("form") CierreCajaAperturaForm form,
+                             BindingResult result,
+                             @AuthenticationPrincipal User userDetails,
+                             Model model,
+                             RedirectAttributes redirectAttributes) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        if (result.hasErrors()) {
+            model.addAttribute("pageTitle", "Apertura de caja");
+            return "cashbox/caja-abrir";
+        }
+        if (cierreCajaService.obtenerCajaAbierta(usuario).isPresent()) {
+            result.reject("caja.abierta", "Ya tienes una caja abierta");
+            model.addAttribute("pageTitle", "Apertura de caja");
+            return "cashbox/caja-abrir";
+        }
+        cierreCajaService.abrirCaja(usuario, form.getMontoInicial());
+        redirectAttributes.addFlashAttribute("toastSuccess", "Caja abierta correctamente");
+        return "redirect:/caja/cerrar";
+    }
+
+    @GetMapping("/cerrar")
+    public String mostrarCierre(Model model,
+                                @AuthenticationPrincipal User userDetails,
+                                RedirectAttributes redirectAttributes) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        Optional<CierreCaja> cajaOpt = cierreCajaService.obtenerCajaAbierta(usuario);
+        if (cajaOpt.isEmpty()) {
+            redirectAttributes.addFlashAttribute("toastInfo", "No tienes una caja abierta actualmente");
+            return "redirect:/caja/historial";
+        }
+        CierreCaja caja = cajaOpt.get();
+        if (!model.containsAttribute("form")) {
+            model.addAttribute("form", new CierreCajaCerrarForm());
+        }
+        CierreCajaResumenDTO resumen = cierreCajaService.generarResumen(caja, caja.getMontoFinal());
+        model.addAttribute("caja", caja);
+        model.addAttribute("resumen", resumen);
+        model.addAttribute("pageTitle", "Cerrar caja");
+        return "cashbox/caja-cerrar";
+    }
+
+    @PostMapping("/cerrar")
+    public String cerrarCaja(@Valid @ModelAttribute("form") CierreCajaCerrarForm form,
+                              BindingResult result,
+                              @AuthenticationPrincipal User userDetails,
+                              Model model,
+                              RedirectAttributes redirectAttributes) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        Optional<CierreCaja> cajaOpt = cierreCajaService.obtenerCajaAbierta(usuario);
+        if (cajaOpt.isEmpty()) {
+            redirectAttributes.addFlashAttribute("toastInfo", "No existe una caja abierta para cerrar");
+            return "redirect:/caja/historial";
+        }
+        CierreCaja caja = cajaOpt.get();
+        if (result.hasErrors()) {
+            CierreCajaResumenDTO resumen = cierreCajaService.generarResumen(caja, form.getMontoFinal());
+            model.addAttribute("caja", caja);
+            model.addAttribute("resumen", resumen);
+            model.addAttribute("pageTitle", "Cerrar caja");
+            return "cashbox/caja-cerrar";
+        }
+        CierreCaja cerrada = cierreCajaService.cerrarCaja(caja, form.getMontoFinal());
+        CierreCajaResumenDTO resumen = cierreCajaService.generarResumen(cerrada, form.getMontoFinal());
+        model.addAttribute("caja", cerrada);
+        model.addAttribute("resumen", resumen);
+        model.addAttribute("cerrada", true);
+        model.addAttribute("pageTitle", "Caja cerrada");
+        model.addAttribute("toastSuccess", "Caja cerrada correctamente");
+        return "cashbox/caja-cerrar";
+    }
+
+    @GetMapping("/historial")
+    public String historial(Model model,
+                            @AuthenticationPrincipal User userDetails) {
+        Usuario usuario = obtenerUsuario(userDetails);
+        List<CierreCaja> historial = cierreCajaService.historial(usuario);
+        Map<Long, CierreCajaResumenDTO> resumenes = historial.stream()
+                .filter(caja -> caja.getEstado() == EstadoCaja.CERRADO)
+                .collect(Collectors.toMap(CierreCaja::getId,
+                        caja -> cierreCajaService.generarResumen(caja, caja.getMontoFinal())));
+        model.addAttribute("historial", historial);
+        model.addAttribute("resumenes", resumenes);
+        model.addAttribute("pageTitle", "Historial de cajas");
+        return "cashbox/caja-historial";
+    }
+
+    private Usuario obtenerUsuario(User userDetails) {
+        if (userDetails == null) {
+            throw new IllegalStateException("No hay usuario autenticado");
+        }
+        return usuarioService.obtenerPorCorreo(userDetails.getUsername());
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Atributo.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Atributo.java
@@ -1,10 +1,11 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 
 @Entity
 @Table(name = "atributo")
-public class Atributo {
+public class Atributo extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/AutorizacionRemota.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/AutorizacionRemota.java
@@ -1,0 +1,134 @@
+package cl.gob.binexus.domain.entity;
+
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
+import cl.gob.binexus.domain.enums.EstadoAutorizacion;
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+
+@Entity
+@Table(name = "autorizacion_remota")
+public class AutorizacionRemota extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_autorizacion_remota")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_usuario", nullable = false)
+    private Usuario solicitante;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_cierre_caja", nullable = false)
+    private CierreCaja cierreCaja;
+
+    @Column(name = "accion", nullable = false, length = 120)
+    private String accion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado_autorizacion", nullable = false, length = 20)
+    private EstadoAutorizacion estado = EstadoAutorizacion.PENDIENTE;
+
+    @Column(name = "codigo_verificacion", nullable = false, length = 6)
+    private String codigoVerificacion;
+
+    @Column(name = "fecha_solicitud", nullable = false)
+    private LocalDateTime fechaSolicitud;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "autorizado_por")
+    private Usuario autorizadoPor;
+
+    @Column(name = "fecha_resolucion")
+    private LocalDateTime fechaResolucion;
+
+    @PrePersist
+    public void prePersist() {
+        if (fechaSolicitud == null) {
+            fechaSolicitud = LocalDateTime.now();
+        }
+        if (codigoVerificacion == null) {
+            codigoVerificacion = generarCodigo();
+        }
+    }
+
+    private String generarCodigo() {
+        Random random = new Random();
+        int numero = random.nextInt(1_000_000);
+        return String.format("%06d", numero);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Usuario getSolicitante() {
+        return solicitante;
+    }
+
+    public void setSolicitante(Usuario solicitante) {
+        this.solicitante = solicitante;
+    }
+
+    public CierreCaja getCierreCaja() {
+        return cierreCaja;
+    }
+
+    public void setCierreCaja(CierreCaja cierreCaja) {
+        this.cierreCaja = cierreCaja;
+    }
+
+    public String getAccion() {
+        return accion;
+    }
+
+    public void setAccion(String accion) {
+        this.accion = accion;
+    }
+
+    public EstadoAutorizacion getEstado() {
+        return estado;
+    }
+
+    public void setEstado(EstadoAutorizacion estado) {
+        this.estado = estado;
+    }
+
+    public String getCodigoVerificacion() {
+        return codigoVerificacion;
+    }
+
+    public void setCodigoVerificacion(String codigoVerificacion) {
+        this.codigoVerificacion = codigoVerificacion;
+    }
+
+    public LocalDateTime getFechaSolicitud() {
+        return fechaSolicitud;
+    }
+
+    public void setFechaSolicitud(LocalDateTime fechaSolicitud) {
+        this.fechaSolicitud = fechaSolicitud;
+    }
+
+    public Usuario getAutorizadoPor() {
+        return autorizadoPor;
+    }
+
+    public void setAutorizadoPor(Usuario autorizadoPor) {
+        this.autorizadoPor = autorizadoPor;
+    }
+
+    public LocalDateTime getFechaResolucion() {
+        return fechaResolucion;
+    }
+
+    public void setFechaResolucion(LocalDateTime fechaResolucion) {
+        this.fechaResolucion = fechaResolucion;
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/CierreCaja.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/CierreCaja.java
@@ -1,0 +1,114 @@
+package cl.gob.binexus.domain.entity;
+
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
+import cl.gob.binexus.domain.enums.EstadoCaja;
+import jakarta.persistence.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "cierre_caja")
+public class CierreCaja extends AuditableEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id_cierre_caja")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "id_usuario", nullable = false)
+    private Usuario usuario;
+
+    @Column(name = "fecha_apertura", nullable = false)
+    private LocalDateTime fechaApertura;
+
+    @Column(name = "fecha_cierre")
+    private LocalDateTime fechaCierre;
+
+    @Column(name = "monto_inicial", precision = 12, scale = 2, nullable = false)
+    private BigDecimal montoInicial = BigDecimal.ZERO;
+
+    @Column(name = "monto_final", precision = 12, scale = 2)
+    private BigDecimal montoFinal;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "estado_caja", nullable = false, length = 20)
+    private EstadoCaja estado = EstadoCaja.ABIERTO;
+
+    @OneToMany(mappedBy = "cierreCaja", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<AutorizacionRemota> autorizaciones = new HashSet<>();
+
+    @PrePersist
+    public void prePersist() {
+        if (fechaApertura == null) {
+            fechaApertura = LocalDateTime.now();
+        }
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Usuario getUsuario() {
+        return usuario;
+    }
+
+    public void setUsuario(Usuario usuario) {
+        this.usuario = usuario;
+    }
+
+    public LocalDateTime getFechaApertura() {
+        return fechaApertura;
+    }
+
+    public void setFechaApertura(LocalDateTime fechaApertura) {
+        this.fechaApertura = fechaApertura;
+    }
+
+    public LocalDateTime getFechaCierre() {
+        return fechaCierre;
+    }
+
+    public void setFechaCierre(LocalDateTime fechaCierre) {
+        this.fechaCierre = fechaCierre;
+    }
+
+    public BigDecimal getMontoInicial() {
+        return montoInicial;
+    }
+
+    public void setMontoInicial(BigDecimal montoInicial) {
+        this.montoInicial = montoInicial;
+    }
+
+    public EstadoCaja getEstado() {
+        return estado;
+    }
+
+    public void setEstado(EstadoCaja estado) {
+        this.estado = estado;
+    }
+
+    public BigDecimal getMontoFinal() {
+        return montoFinal;
+    }
+
+    public void setMontoFinal(BigDecimal montoFinal) {
+        this.montoFinal = montoFinal;
+    }
+
+    public Set<AutorizacionRemota> getAutorizaciones() {
+        return autorizaciones;
+    }
+
+    public void setAutorizaciones(Set<AutorizacionRemota> autorizaciones) {
+        this.autorizaciones = autorizaciones;
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Cliente.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Cliente.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoCliente;
 import jakarta.persistence.*;
 
@@ -7,7 +8,7 @@ import jakarta.persistence.*;
 @Table(name = "cliente", uniqueConstraints = {
         @UniqueConstraint(name = "uk_cliente_org_correo", columnNames = {"id_organizacion", "correo_cliente"})
 })
-public class Cliente {
+public class Cliente extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/DetalleVenta.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/DetalleVenta.java
@@ -1,12 +1,13 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
 
 @Entity
 @Table(name = "detalle_venta")
-public class DetalleVenta {
+public class DetalleVenta extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Inventario.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Inventario.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
@@ -10,7 +11,7 @@ import java.util.List;
 @Table(name = "inventario", uniqueConstraints = {
         @UniqueConstraint(name = "uk_inventario_producto_org", columnNames = {"id_producto", "id_organizacion"})
 })
-public class Inventario {
+public class Inventario extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Local.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Local.java
@@ -1,12 +1,13 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoLocal;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "local")
-public class Local {
+public class Local extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/MovimientoInventario.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/MovimientoInventario.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.TipoMovimientoInventario;
 import jakarta.persistence.*;
 
@@ -8,7 +9,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "movimiento_inventario")
-public class MovimientoInventario {
+public class MovimientoInventario extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Organizacion.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Organizacion.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoOrganizacion;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -8,7 +9,7 @@ import java.util.List;
 
 @Entity
 @Table(name = "organizacion")
-public class Organizacion {
+public class Organizacion extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Parametro.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Parametro.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoParametro;
 import jakarta.persistence.*;
 
@@ -7,7 +8,7 @@ import jakarta.persistence.*;
 @Table(name = "parametro", uniqueConstraints = {
         @UniqueConstraint(name = "uk_parametro_tipo_descripcion", columnNames = {"id_tipo_parametro", "descripcion_parametro"})
 })
-public class Parametro {
+public class Parametro extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/PrecioProducto.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/PrecioProducto.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 
 import java.math.BigDecimal;
@@ -7,7 +8,7 @@ import java.time.LocalDate;
 
 @Entity
 @Table(name = "precio_producto")
-public class PrecioProducto {
+public class PrecioProducto extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Privilegio.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Privilegio.java
@@ -1,10 +1,11 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 
 @Entity
 @Table(name = "privilegio")
-public class Privilegio {
+public class Privilegio extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Producto.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Producto.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoProducto;
 import jakarta.persistence.*;
 
@@ -13,7 +14,7 @@ import java.util.List;
         @Index(name = "idx_producto_nombre", columnList = "nombre_producto"),
         @Index(name = "idx_producto_estado", columnList = "estado_producto")
 })
-public class Producto {
+public class Producto extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Rol.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Rol.java
@@ -1,12 +1,13 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
 
 @Entity
 @Table(name = "rol")
-public class Rol {
+public class Rol extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/TipoParametro.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/TipoParametro.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import jakarta.persistence.*;
 
 import java.util.HashSet;
@@ -7,7 +8,7 @@ import java.util.Set;
 
 @Entity
 @Table(name = "tipo_parametro")
-public class TipoParametro {
+public class TipoParametro extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Usuario.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Usuario.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoUsuario;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
@@ -8,7 +9,7 @@ import java.util.Set;
 
 @Entity
 @Table(name = "usuario")
-public class Usuario {
+public class Usuario extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Venta.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/Venta.java
@@ -1,5 +1,6 @@
 package cl.gob.binexus.domain.entity;
 
+import cl.gob.binexus.domain.entity.support.AuditableEntity;
 import cl.gob.binexus.domain.enums.EstadoPago;
 import cl.gob.binexus.domain.enums.MetodoPago;
 import cl.gob.binexus.domain.enums.TipoVenta;
@@ -16,7 +17,7 @@ import java.util.UUID;
         @Index(name = "idx_venta_fecha", columnList = "fecha_venta"),
         @Index(name = "idx_venta_order", columnList = "order_id", unique = true)
 })
-public class Venta {
+public class Venta extends AuditableEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/support/AuditableEntity.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/entity/support/AuditableEntity.java
@@ -1,0 +1,39 @@
+package cl.gob.binexus.domain.entity.support;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class AuditableEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/enums/EstadoAutorizacion.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/enums/EstadoAutorizacion.java
@@ -1,0 +1,7 @@
+package cl.gob.binexus.domain.enums;
+
+public enum EstadoAutorizacion {
+    PENDIENTE,
+    APROBADA,
+    RECHAZADA
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/domain/enums/EstadoCaja.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/domain/enums/EstadoCaja.java
@@ -1,0 +1,6 @@
+package cl.gob.binexus.domain.enums;
+
+public enum EstadoCaja {
+    ABIERTO,
+    CERRADO
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/dto/CierreCajaAperturaForm.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/dto/CierreCajaAperturaForm.java
@@ -1,0 +1,23 @@
+package cl.gob.binexus.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public class CierreCajaAperturaForm {
+
+    @NotNull(message = "Debe ingresar un monto inicial")
+    @DecimalMin(value = "0.0", inclusive = true, message = "El monto debe ser positivo")
+    @Digits(integer = 12, fraction = 2, message = "Formato inválido")
+    private BigDecimal montoInicial;
+
+    public BigDecimal getMontoInicial() {
+        return montoInicial;
+    }
+
+    public void setMontoInicial(BigDecimal montoInicial) {
+        this.montoInicial = montoInicial;
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/dto/CierreCajaCerrarForm.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/dto/CierreCajaCerrarForm.java
@@ -1,0 +1,23 @@
+package cl.gob.binexus.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public class CierreCajaCerrarForm {
+
+    @NotNull(message = "Debe indicar el monto final contado")
+    @DecimalMin(value = "0.0", inclusive = true, message = "El monto debe ser positivo")
+    @Digits(integer = 12, fraction = 2, message = "Formato inválido")
+    private BigDecimal montoFinal;
+
+    public BigDecimal getMontoFinal() {
+        return montoFinal;
+    }
+
+    public void setMontoFinal(BigDecimal montoFinal) {
+        this.montoFinal = montoFinal;
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/dto/CierreCajaResumenDTO.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/dto/CierreCajaResumenDTO.java
@@ -1,0 +1,59 @@
+package cl.gob.binexus.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class CierreCajaResumenDTO {
+
+    private final BigDecimal montoInicial;
+    private final BigDecimal montoFinalEsperado;
+    private final BigDecimal montoFinalDeclarado;
+    private final BigDecimal diferencia;
+    private final BigDecimal totalVentas;
+    private final LocalDateTime fechaApertura;
+    private final LocalDateTime fechaCierre;
+
+    public CierreCajaResumenDTO(BigDecimal montoInicial,
+                                BigDecimal montoFinalEsperado,
+                                BigDecimal montoFinalDeclarado,
+                                BigDecimal diferencia,
+                                BigDecimal totalVentas,
+                                LocalDateTime fechaApertura,
+                                LocalDateTime fechaCierre) {
+        this.montoInicial = montoInicial;
+        this.montoFinalEsperado = montoFinalEsperado;
+        this.montoFinalDeclarado = montoFinalDeclarado;
+        this.diferencia = diferencia;
+        this.totalVentas = totalVentas;
+        this.fechaApertura = fechaApertura;
+        this.fechaCierre = fechaCierre;
+    }
+
+    public BigDecimal getMontoInicial() {
+        return montoInicial;
+    }
+
+    public BigDecimal getMontoFinalEsperado() {
+        return montoFinalEsperado;
+    }
+
+    public BigDecimal getMontoFinalDeclarado() {
+        return montoFinalDeclarado;
+    }
+
+    public BigDecimal getDiferencia() {
+        return diferencia;
+    }
+
+    public BigDecimal getTotalVentas() {
+        return totalVentas;
+    }
+
+    public LocalDateTime getFechaApertura() {
+        return fechaApertura;
+    }
+
+    public LocalDateTime getFechaCierre() {
+        return fechaCierre;
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/repository/AutorizacionRemotaRepository.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/repository/AutorizacionRemotaRepository.java
@@ -1,0 +1,18 @@
+package cl.gob.binexus.repository;
+
+import cl.gob.binexus.domain.entity.AutorizacionRemota;
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoAutorizacion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AutorizacionRemotaRepository extends JpaRepository<AutorizacionRemota, Long> {
+
+    List<AutorizacionRemota> findByEstadoOrderByFechaSolicitudDesc(EstadoAutorizacion estado);
+
+    List<AutorizacionRemota> findBySolicitanteOrderByFechaSolicitudDesc(Usuario solicitante);
+
+    List<AutorizacionRemota> findByCierreCajaOrderByFechaSolicitudDesc(CierreCaja cierreCaja);
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/repository/CierreCajaRepository.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/repository/CierreCajaRepository.java
@@ -1,0 +1,18 @@
+package cl.gob.binexus.repository;
+
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoCaja;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CierreCajaRepository extends JpaRepository<CierreCaja, Long> {
+
+    Optional<CierreCaja> findFirstByUsuarioAndEstadoOrderByFechaAperturaDesc(Usuario usuario, EstadoCaja estado);
+
+    boolean existsByUsuarioAndEstado(Usuario usuario, EstadoCaja estado);
+
+    List<CierreCaja> findByUsuarioOrderByFechaAperturaDesc(Usuario usuario);
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/repository/VentaRepository.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/repository/VentaRepository.java
@@ -2,12 +2,14 @@ package cl.gob.binexus.repository;
 
 import cl.gob.binexus.domain.entity.Local;
 import cl.gob.binexus.domain.entity.Organizacion;
+import cl.gob.binexus.domain.entity.Usuario;
 import cl.gob.binexus.domain.entity.Venta;
 import cl.gob.binexus.domain.enums.EstadoPago;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,4 +34,10 @@ public interface VentaRepository extends JpaRepository<Venta, Long> {
     List<Object[]> totalPorDia(@Param("organizacion") Organizacion organizacion,
                                @Param("desde") LocalDateTime desde,
                                @Param("hasta") LocalDateTime hasta);
+
+    @Query("SELECT COALESCE(SUM(v.montoFinal), 0) FROM Venta v " +
+            "WHERE v.usuario = :usuario AND v.fechaVenta BETWEEN :desde AND :hasta")
+    BigDecimal totalPorUsuarioYRango(@Param("usuario") Usuario usuario,
+                                     @Param("desde") LocalDateTime desde,
+                                     @Param("hasta") LocalDateTime hasta);
 }

--- a/binexus-erp/src/main/java/cl/gob/binexus/service/AutorizacionRemotaService.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/service/AutorizacionRemotaService.java
@@ -1,0 +1,19 @@
+package cl.gob.binexus.service;
+
+import cl.gob.binexus.domain.entity.AutorizacionRemota;
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoAutorizacion;
+
+import java.util.List;
+
+public interface AutorizacionRemotaService {
+
+    AutorizacionRemota solicitar(Usuario solicitante, CierreCaja cierreCaja, String accion);
+
+    AutorizacionRemota resolver(Long autorizacionId, Usuario aprobador, EstadoAutorizacion estado);
+
+    List<AutorizacionRemota> listarPorEstado(EstadoAutorizacion estado);
+
+    List<AutorizacionRemota> listarPorSolicitante(Usuario solicitante);
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/service/CierreCajaService.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/service/CierreCajaService.java
@@ -1,0 +1,22 @@
+package cl.gob.binexus.service;
+
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.dto.CierreCajaResumenDTO;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+public interface CierreCajaService {
+
+    CierreCaja abrirCaja(Usuario usuario, BigDecimal montoInicial);
+
+    CierreCaja cerrarCaja(CierreCaja cierreCaja, BigDecimal montoFinal);
+
+    Optional<CierreCaja> obtenerCajaAbierta(Usuario usuario);
+
+    List<CierreCaja> historial(Usuario usuario);
+
+    CierreCajaResumenDTO generarResumen(CierreCaja cierreCaja, BigDecimal montoFinalDeclarado);
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/service/impl/AutorizacionRemotaServiceImpl.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/service/impl/AutorizacionRemotaServiceImpl.java
@@ -1,0 +1,93 @@
+package cl.gob.binexus.service.impl;
+
+import cl.gob.binexus.domain.entity.AutorizacionRemota;
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Rol;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoAutorizacion;
+import cl.gob.binexus.domain.enums.EstadoCaja;
+import cl.gob.binexus.repository.AutorizacionRemotaRepository;
+import cl.gob.binexus.service.AutorizacionRemotaService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+public class AutorizacionRemotaServiceImpl implements AutorizacionRemotaService {
+
+    private static final String ROL_SUPERIOR = "ROLE_ADMIN";
+
+    private final AutorizacionRemotaRepository autorizacionRemotaRepository;
+
+    public AutorizacionRemotaServiceImpl(AutorizacionRemotaRepository autorizacionRemotaRepository) {
+        this.autorizacionRemotaRepository = autorizacionRemotaRepository;
+    }
+
+    @Override
+    public AutorizacionRemota solicitar(Usuario solicitante, CierreCaja cierreCaja, String accion) {
+        if (solicitante == null || cierreCaja == null) {
+            throw new IllegalArgumentException("Datos incompletos para la solicitud");
+        }
+        if (!StringUtils.hasText(accion)) {
+            throw new IllegalArgumentException("La acción a autorizar es obligatoria");
+        }
+        if (cierreCaja.getEstado() != EstadoCaja.ABIERTO) {
+            throw new IllegalStateException("La autorización solo puede asociarse a cajas abiertas");
+        }
+        AutorizacionRemota autorizacion = new AutorizacionRemota();
+        autorizacion.setSolicitante(solicitante);
+        autorizacion.setCierreCaja(cierreCaja);
+        autorizacion.setAccion(accion.trim());
+        autorizacion.setEstado(EstadoAutorizacion.PENDIENTE);
+        return autorizacionRemotaRepository.save(autorizacion);
+    }
+
+    @Override
+    public AutorizacionRemota resolver(Long autorizacionId, Usuario aprobador, EstadoAutorizacion estado) {
+        if (autorizacionId == null || aprobador == null) {
+            throw new IllegalArgumentException("Datos incompletos para resolver la autorización");
+        }
+        if (estado == null || estado == EstadoAutorizacion.PENDIENTE) {
+            throw new IllegalArgumentException("Estado inválido");
+        }
+        AutorizacionRemota autorizacion = autorizacionRemotaRepository.findById(autorizacionId)
+                .orElseThrow(() -> new EntityNotFoundException("Autorización no encontrada"));
+        if (autorizacion.getEstado() != EstadoAutorizacion.PENDIENTE) {
+            throw new IllegalStateException("La autorización ya fue resuelta");
+        }
+        if (autorizacion.getSolicitante().getId().equals(aprobador.getId())) {
+            throw new IllegalStateException("El solicitante no puede aprobar su propia autorización");
+        }
+        if (aprobador.getRoles().stream().map(Rol::getNombre).noneMatch(ROL_SUPERIOR::equals)) {
+            throw new IllegalStateException("El usuario no tiene privilegios para aprobar");
+        }
+        autorizacion.setEstado(estado);
+        autorizacion.setAutorizadoPor(aprobador);
+        autorizacion.setFechaResolucion(LocalDateTime.now());
+        return autorizacionRemotaRepository.save(autorizacion);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AutorizacionRemota> listarPorEstado(EstadoAutorizacion estado) {
+        if (estado == null) {
+            return autorizacionRemotaRepository.findAll(Sort.by(Sort.Direction.DESC, "fechaSolicitud"));
+        }
+        return autorizacionRemotaRepository.findByEstadoOrderByFechaSolicitudDesc(estado);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AutorizacionRemota> listarPorSolicitante(Usuario solicitante) {
+        if (solicitante == null) {
+            throw new IllegalArgumentException("Solicitante requerido");
+        }
+        return autorizacionRemotaRepository.findBySolicitanteOrderByFechaSolicitudDesc(solicitante);
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/service/impl/CierreCajaServiceImpl.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/service/impl/CierreCajaServiceImpl.java
@@ -1,0 +1,116 @@
+package cl.gob.binexus.service.impl;
+
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoCaja;
+import cl.gob.binexus.dto.CierreCajaResumenDTO;
+import cl.gob.binexus.repository.CierreCajaRepository;
+import cl.gob.binexus.repository.VentaRepository;
+import cl.gob.binexus.service.CierreCajaService;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+public class CierreCajaServiceImpl implements CierreCajaService {
+
+    private final CierreCajaRepository cierreCajaRepository;
+    private final VentaRepository ventaRepository;
+
+    public CierreCajaServiceImpl(CierreCajaRepository cierreCajaRepository,
+                                 VentaRepository ventaRepository) {
+        this.cierreCajaRepository = cierreCajaRepository;
+        this.ventaRepository = ventaRepository;
+    }
+
+    @Override
+    public CierreCaja abrirCaja(Usuario usuario, BigDecimal montoInicial) {
+        if (usuario == null) {
+            throw new IllegalArgumentException("Usuario requerido");
+        }
+        if (montoInicial == null || montoInicial.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("El monto inicial debe ser mayor o igual a cero");
+        }
+        if (cierreCajaRepository.existsByUsuarioAndEstado(usuario, EstadoCaja.ABIERTO)) {
+            throw new IllegalStateException("El usuario ya tiene una caja abierta");
+        }
+        CierreCaja caja = new CierreCaja();
+        caja.setUsuario(usuario);
+        caja.setMontoInicial(montoInicial);
+        caja.setEstado(EstadoCaja.ABIERTO);
+        return cierreCajaRepository.save(caja);
+    }
+
+    @Override
+    public CierreCaja cerrarCaja(CierreCaja cierreCaja, BigDecimal montoFinal) {
+        if (cierreCaja == null || cierreCaja.getId() == null) {
+            throw new IllegalArgumentException("Caja no válida");
+        }
+        CierreCaja existente = cierreCajaRepository.findById(cierreCaja.getId())
+                .orElseThrow(() -> new EntityNotFoundException("Caja no encontrada"));
+        if (existente.getEstado() != EstadoCaja.ABIERTO) {
+            throw new IllegalStateException("La caja ya fue cerrada");
+        }
+        existente.setEstado(EstadoCaja.CERRADO);
+        existente.setFechaCierre(LocalDateTime.now());
+        existente.setMontoFinal(montoFinal);
+        return cierreCajaRepository.save(existente);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<CierreCaja> obtenerCajaAbierta(Usuario usuario) {
+        if (usuario == null) {
+            return Optional.empty();
+        }
+        return cierreCajaRepository.findFirstByUsuarioAndEstadoOrderByFechaAperturaDesc(usuario, EstadoCaja.ABIERTO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CierreCaja> historial(Usuario usuario) {
+        if (usuario == null) {
+            throw new IllegalArgumentException("Usuario requerido");
+        }
+        return cierreCajaRepository.findByUsuarioOrderByFechaAperturaDesc(usuario);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CierreCajaResumenDTO generarResumen(CierreCaja cierreCaja, BigDecimal montoFinalDeclarado) {
+        if (cierreCaja == null) {
+            throw new IllegalArgumentException("Caja requerida");
+        }
+        LocalDateTime fechaFin = cierreCaja.getFechaCierre() != null ? cierreCaja.getFechaCierre() : LocalDateTime.now();
+        BigDecimal totalVentas = ventaRepository.totalPorUsuarioYRango(
+                cierreCaja.getUsuario(),
+                cierreCaja.getFechaApertura(),
+                fechaFin
+        );
+        if (totalVentas == null) {
+            totalVentas = BigDecimal.ZERO;
+        }
+        BigDecimal montoInicial = cierreCaja.getMontoInicial() != null ? cierreCaja.getMontoInicial() : BigDecimal.ZERO;
+        BigDecimal esperado = montoInicial.add(totalVentas);
+        BigDecimal declarado = montoFinalDeclarado != null ? montoFinalDeclarado : cierreCaja.getMontoFinal();
+        if (declarado == null) {
+            declarado = esperado;
+        }
+        BigDecimal diferencia = declarado.subtract(esperado);
+        return new CierreCajaResumenDTO(
+                montoInicial,
+                esperado,
+                declarado,
+                diferencia,
+                totalVentas,
+                cierreCaja.getFechaApertura(),
+                fechaFin
+        );
+    }
+}

--- a/binexus-erp/src/main/java/cl/gob/binexus/service/impl/VentaServiceImpl.java
+++ b/binexus-erp/src/main/java/cl/gob/binexus/service/impl/VentaServiceImpl.java
@@ -10,6 +10,7 @@ import cl.gob.binexus.domain.enums.EstadoPago;
 import cl.gob.binexus.domain.enums.TipoMovimientoInventario;
 import cl.gob.binexus.repository.ProductoRepository;
 import cl.gob.binexus.repository.VentaRepository;
+import cl.gob.binexus.service.CierreCajaService;
 import cl.gob.binexus.service.InventarioService;
 import cl.gob.binexus.service.VentaService;
 import jakarta.persistence.EntityNotFoundException;
@@ -31,13 +32,16 @@ public class VentaServiceImpl implements VentaService {
     private final VentaRepository ventaRepository;
     private final ProductoRepository productoRepository;
     private final InventarioService inventarioService;
+    private final CierreCajaService cierreCajaService;
 
     public VentaServiceImpl(VentaRepository ventaRepository,
                             ProductoRepository productoRepository,
-                            InventarioService inventarioService) {
+                            InventarioService inventarioService,
+                            CierreCajaService cierreCajaService) {
         this.ventaRepository = ventaRepository;
         this.productoRepository = productoRepository;
         this.inventarioService = inventarioService;
+        this.cierreCajaService = cierreCajaService;
     }
 
     @Override
@@ -60,6 +64,9 @@ public class VentaServiceImpl implements VentaService {
         if (venta.getDetalles() == null || venta.getDetalles().isEmpty()) {
             throw new IllegalArgumentException("Debe agregar al menos un producto a la venta");
         }
+
+        cierreCajaService.obtenerCajaAbierta(venta.getUsuario())
+                .orElseThrow(() -> new IllegalArgumentException("Debe abrir una caja antes de registrar ventas"));
 
         List<DetalleVenta> detallesPreparados = new ArrayList<>();
         Map<Long, Inventario> inventarios = new HashMap<>();

--- a/binexus-erp/src/main/resources/db/migration/V3__caja_autorizaciones_auditoria.sql
+++ b/binexus-erp/src/main/resources/db/migration/V3__caja_autorizaciones_auditoria.sql
@@ -1,0 +1,81 @@
+-- Auditoría base para entidades principales
+ALTER TABLE usuario ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE usuario ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE organizacion ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE organizacion ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE local ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE local ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE producto ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE producto ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE cliente ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE cliente ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE inventario ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE inventario ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE movimiento_inventario ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE movimiento_inventario ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE parametro ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE parametro ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE tipo_parametro ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE tipo_parametro ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE precio_producto ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE precio_producto ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE atributo ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE atributo ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE privilegio ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE privilegio ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE rol ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE rol ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE venta ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE venta ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+ALTER TABLE detalle_venta ADD COLUMN IF NOT EXISTS created_at TIMESTAMP NOT NULL DEFAULT NOW();
+ALTER TABLE detalle_venta ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP;
+
+-- Cierre de caja
+CREATE TABLE IF NOT EXISTS cierre_caja (
+    id_cierre_caja SERIAL PRIMARY KEY,
+    id_usuario INTEGER NOT NULL REFERENCES usuario(id_usuario),
+    fecha_apertura TIMESTAMP NOT NULL DEFAULT NOW(),
+    fecha_cierre TIMESTAMP,
+    monto_inicial NUMERIC(12,2) NOT NULL DEFAULT 0,
+    monto_final NUMERIC(12,2),
+    estado_caja VARCHAR(20) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP,
+    CONSTRAINT chk_estado_caja CHECK (estado_caja IN ('ABIERTO','CERRADO'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_cierre_caja_usuario ON cierre_caja(id_usuario);
+CREATE INDEX IF NOT EXISTS idx_cierre_caja_estado ON cierre_caja(estado_caja);
+
+-- Autorizaciones remotas
+CREATE TABLE IF NOT EXISTS autorizacion_remota (
+    id_autorizacion_remota SERIAL PRIMARY KEY,
+    id_usuario INTEGER NOT NULL REFERENCES usuario(id_usuario),
+    id_cierre_caja INTEGER NOT NULL REFERENCES cierre_caja(id_cierre_caja) ON DELETE CASCADE,
+    accion VARCHAR(120) NOT NULL,
+    estado_autorizacion VARCHAR(20) NOT NULL,
+    codigo_verificacion VARCHAR(6) NOT NULL,
+    fecha_solicitud TIMESTAMP NOT NULL DEFAULT NOW(),
+    autorizado_por INTEGER REFERENCES usuario(id_usuario),
+    fecha_resolucion TIMESTAMP,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP,
+    CONSTRAINT chk_estado_autorizacion CHECK (estado_autorizacion IN ('PENDIENTE','APROBADA','RECHAZADA'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_autorizacion_estado ON autorizacion_remota(estado_autorizacion);
+CREATE UNIQUE INDEX IF NOT EXISTS uk_autorizacion_codigo ON autorizacion_remota(codigo_verificacion);

--- a/binexus-erp/src/main/resources/static/css/styles.css
+++ b/binexus-erp/src/main/resources/static/css/styles.css
@@ -53,6 +53,26 @@ body.layout-body {
     min-width: 280px;
 }
 
+#global-loader {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(3px);
+    z-index: 1080;
+}
+
+[data-bs-theme='light'] #global-loader {
+    background-color: rgba(248, 249, 250, 0.75);
+}
+
+#global-loader .spinner-border {
+    width: 3rem;
+    height: 3rem;
+}
+
 @media (max-width: 992px) {
     .sidebar {
         position: fixed;

--- a/binexus-erp/src/main/resources/static/js/app.js
+++ b/binexus-erp/src/main/resources/static/js/app.js
@@ -3,6 +3,7 @@
     const sidebarToggle = document.getElementById('sidebarToggle');
     const themeToggle = document.getElementById('themeToggle');
     const toastContainer = document.getElementById('toast-container');
+    const loader = document.getElementById('global-loader');
 
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const storedTheme = localStorage.getItem('binexus-theme');
@@ -58,9 +59,15 @@
 
     document.addEventListener('DOMContentLoaded', () => {
         initTheme();
-        const toastMessage = document.body.dataset.toastSuccess;
-        if (toastMessage) {
-            showToast(toastMessage, 'success');
+        const {toastSuccess, toastError, toastInfo} = document.body.dataset;
+        if (toastSuccess) {
+            showToast(toastSuccess, 'success');
+        }
+        if (toastError) {
+            showToast(toastError, 'danger');
+        }
+        if (toastInfo) {
+            showToast(toastInfo, 'info');
         }
 
         document.querySelectorAll('form.needs-validation').forEach(form => {
@@ -68,9 +75,19 @@
                 if (!form.checkValidity()) {
                     event.preventDefault();
                     event.stopPropagation();
+                } else if (form.dataset.showLoader === 'true' && loader) {
+                    loader.classList.remove('d-none');
                 }
                 form.classList.add('was-validated');
             }, false);
+        });
+
+        document.querySelectorAll('form[data-show-loader="true"]:not(.needs-validation)').forEach(form => {
+            form.addEventListener('submit', () => {
+                if (loader) {
+                    loader.classList.remove('d-none');
+                }
+            });
         });
     });
 

--- a/binexus-erp/src/main/resources/templates/authorizations/autorizaciones-list.html
+++ b/binexus-erp/src/main/resources/templates/authorizations/autorizaciones-list.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<head>
+    <title>Autorizaciones remotas</title>
+</head>
+<body>
+<section layout:fragment="content" class="col-xxl-10 mx-auto">
+    <div class="d-flex flex-wrap justify-content-between align-items-center mb-4 gap-3">
+        <div>
+            <h1 class="h3 fw-bold mb-1">Autorizaciones remotas</h1>
+            <p class="text-muted mb-0">Solicita permisos especiales y gestiona las aprobaciones en tiempo real.</p>
+        </div>
+        <form class="d-flex gap-2 align-items-center" method="get" th:action="@{/autorizaciones}">
+            <label class="visually-hidden" for="estado">Estado</label>
+            <select class="form-select" id="estado" name="estado">
+                <option value="" th:selected="${estadoSeleccionado == null}">Todos</option>
+                <option th:each="estado : ${estados}" th:value="${estado}" th:selected="${estado == estadoSeleccionado}"
+                        th:text="${estado}"></option>
+            </select>
+            <button type="submit" class="btn btn-outline-primary"><i class="bi bi-filter me-1"></i>Filtrar</button>
+        </form>
+    </div>
+
+    <div class="row g-4">
+        <div class="col-lg-4" th:if="${caja != null}">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <h2 class="h5 fw-semibold mb-2">Solicitar autorización</h2>
+                    <p class="text-muted">Describe la acción que requiere aprobación y enviaremos una alerta al supervisor.</p>
+                    <form th:action="@{/autorizaciones}" method="post" data-show-loader="true" class="needs-validation" novalidate>
+                        <div class="mb-3">
+                            <label class="form-label" for="accion">Acción requerida</label>
+                            <input type="text" class="form-control" id="accion" name="accion" maxlength="120" required
+                                   aria-describedby="accionHelp">
+                            <small id="accionHelp" class="form-text text-muted">Ejemplo: "Modificar precio" o "Anular venta".</small>
+                            <div class="invalid-feedback">Describe la acción que necesitas autorizar.</div>
+                        </div>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <button type="submit" class="btn btn-primary w-100">
+                            <i class="bi bi-send me-1"></i>Solicitar autorización
+                        </button>
+                        <p class="small text-muted mt-3 mb-0">Caja abierta desde
+                            <strong th:text="${#temporals.format(caja.fechaApertura, 'dd/MM/yyyy HH:mm')}"></strong>.
+                        </p>
+                    </form>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg" th:classappend="${caja == null} ? ' col-12'">
+            <div class="card border-0 shadow-sm">
+                <div class="table-responsive">
+                    <table class="table align-middle mb-0">
+                        <thead class="table-light">
+                        <tr>
+                            <th scope="col">Acción</th>
+                            <th scope="col">Solicitante</th>
+                            <th scope="col">Estado</th>
+                            <th scope="col">Código</th>
+                            <th scope="col">Solicitada</th>
+                            <th scope="col">Resuelta</th>
+                            <th scope="col">Autorizada por</th>
+                            <th scope="col" class="text-end">Acciones</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:if="${autorizaciones.isEmpty()}">
+                            <td colspan="8" class="text-center py-5 text-muted">No se registran autorizaciones para el filtro seleccionado.</td>
+                        </tr>
+                        <tr th:each="autorizacion : ${autorizaciones}">
+                            <td>
+                                <strong th:text="${autorizacion.accion}"></strong>
+                            </td>
+                            <td>
+                                <span th:text="${autorizacion.solicitante.nombre}"></span>
+                                <small class="d-block text-muted" th:text="${autorizacion.solicitante.correo}"></small>
+                            </td>
+                            <td>
+                                <span class="badge rounded-pill"
+                                      th:classappend="${autorizacion.estado.name() == 'APROBADA'} ? ' bg-success-subtle text-success-emphasis' : (autorizacion.estado.name() == 'RECHAZADA' ? ' bg-danger-subtle text-danger-emphasis' : ' bg-warning-subtle text-warning-emphasis')"
+                                      th:text="${autorizacion.estado}"></span>
+                            </td>
+                            <td><code th:text="${autorizacion.codigoVerificacion}"></code></td>
+                            <td th:text="${#temporals.format(autorizacion.fechaSolicitud, 'dd/MM/yyyy HH:mm')}"></td>
+                            <td th:text="${autorizacion.fechaResolucion != null ? #temporals.format(autorizacion.fechaResolucion, 'dd/MM/yyyy HH:mm') : '-'}"></td>
+                            <td th:text="${autorizacion.autorizadoPor != null ? autorizacion.autorizadoPor.nombre : '-'}"></td>
+                            <td class="text-end">
+                                <div th:if="${autorizacion.estado.name() == 'PENDIENTE'}" class="btn-group" role="group"
+                                     aria-label="Resolver autorización">
+                                    <button type="button" class="btn btn-outline-success btn-sm btn-resolver"
+                                            data-estado="APROBADA" th:data-id="${autorizacion.id}">
+                                        <i class="bi bi-check-circle me-1"></i>Aprobar
+                                    </button>
+                                    <button type="button" class="btn btn-outline-danger btn-sm btn-resolver"
+                                            data-estado="RECHAZADA" th:data-id="${autorizacion.id}">
+                                        <i class="bi bi-x-circle me-1"></i>Rechazar
+                                    </button>
+                                </div>
+                                <span th:if="${autorizacion.estado.name() != 'PENDIENTE'}" class="text-muted">Sin acciones</span>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+    <form id="resolverForm" method="post" class="d-none">
+        <input type="hidden" name="estado" id="resolverEstado">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+    </form>
+</section>
+<script type="text/javascript">
+    document.addEventListener('DOMContentLoaded', function () {
+        const resolverForm = document.getElementById('resolverForm');
+        const estadoInput = document.getElementById('resolverEstado');
+        document.querySelectorAll('.btn-resolver').forEach((button) => {
+            button.addEventListener('click', () => {
+                const id = button.dataset.id;
+                const estado = button.dataset.estado;
+                const actionUrl = `/autorizaciones/${id}/resolver`;
+                Swal.fire({
+                    title: estado === 'APROBADA' ? '¿Aprobar solicitud?' : '¿Rechazar solicitud?',
+                    text: 'Esta acción no se puede deshacer.',
+                    icon: estado === 'APROBADA' ? 'success' : 'warning',
+                    showCancelButton: true,
+                    confirmButtonText: estado === 'APROBADA' ? 'Sí, aprobar' : 'Sí, rechazar',
+                    cancelButtonText: 'Cancelar',
+                    focusCancel: true
+                }).then(result => {
+                    if (result.isConfirmed) {
+                        resolverForm.action = actionUrl;
+                        estadoInput.value = estado;
+                        resolverForm.submit();
+                    }
+                });
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/binexus-erp/src/main/resources/templates/cashbox/caja-abrir.html
+++ b/binexus-erp/src/main/resources/templates/cashbox/caja-abrir.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<head>
+    <title>Apertura de caja</title>
+</head>
+<body>
+<section layout:fragment="content" class="col-lg-8 mx-auto">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h1 class="h3 fw-bold mb-1">Apertura de caja</h1>
+            <p class="text-muted mb-0">Registra el monto inicial disponible en tu caja para habilitar las ventas.</p>
+        </div>
+        <a class="btn btn-outline-secondary" th:href="@{/dashboard}"><i class="bi bi-arrow-left me-1"></i>Volver</a>
+    </div>
+    <div class="card shadow-sm border-0">
+        <div class="card-body p-4">
+            <form th:action="@{/caja/abrir}" th:object="${form}" method="post" class="needs-validation" novalidate
+                  data-show-loader="true">
+                <div class="mb-3">
+                    <label class="form-label" for="montoInicial">Monto inicial</label>
+                    <div class="input-group">
+                        <span class="input-group-text" id="addon-moneda">$</span>
+                        <input type="number" class="form-control" id="montoInicial" th:field="*{montoInicial}" step="0.01"
+                               min="0" aria-describedby="addon-moneda montoInicialHelp" required>
+                    </div>
+                    <small id="montoInicialHelp" class="form-text text-muted">Utiliza punto para separar los decimales.</small>
+                    <div class="invalid-feedback" th:if="${#fields.hasErrors('montoInicial')}" th:errors="*{montoInicial}"></div>
+                </div>
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                <div class="d-flex justify-content-end">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-door-open me-1"></i>Abrir caja
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</section>
+</body>
+</html>

--- a/binexus-erp/src/main/resources/templates/cashbox/caja-cerrar.html
+++ b/binexus-erp/src/main/resources/templates/cashbox/caja-cerrar.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<head>
+    <title>Cerrar caja</title>
+</head>
+<body>
+<section layout:fragment="content" class="col-lg-10 mx-auto">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h1 class="h3 fw-bold mb-1" th:text="${pageTitle}">Cerrar caja</h1>
+            <p class="text-muted mb-0">Revisa los totales registrados y confirma el monto contado para cerrar la caja.</p>
+        </div>
+        <a class="btn btn-outline-secondary" th:href="@{/caja/historial}"><i class="bi bi-clock-history me-1"></i>Historial</a>
+    </div>
+    <div class="row g-4">
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-header bg-transparent border-bottom-0 pb-0">
+                    <h2 class="h5 fw-semibold mb-0">Resumen</h2>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <span class="text-muted">Fecha apertura</span>
+                        <strong th:text="${#temporals.format(resumen.fechaApertura, 'dd/MM/yyyy HH:mm')}"></strong>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <span class="text-muted">Total ventas</span>
+                        <strong th:text="${#numbers.formatCurrency(resumen.totalVentas)}"></strong>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <span class="text-muted">Monto inicial</span>
+                        <strong th:text="${#numbers.formatCurrency(resumen.montoInicial)}"></strong>
+                    </div>
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <span class="text-muted">Monto esperado</span>
+                        <strong th:text="${#numbers.formatCurrency(resumen.montoFinalEsperado)}"></strong>
+                    </div>
+                    <div class="alert" th:classappend="${resumen.diferencia.signum() == 0} ? ' alert-success' : (resumen.diferencia.signum() > 0 ? ' alert-warning' : ' alert-danger')">
+                        <div class="d-flex justify-content-between align-items-center">
+                            <span>Diferencia</span>
+                            <strong th:text="${#numbers.formatCurrency(resumen.diferencia)}"></strong>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card border-0 shadow-sm h-100">
+                <div class="card-body">
+                    <div class="mb-4">
+                        <h2 class="h5 fw-semibold mb-1">Confirmar cierre</h2>
+                        <p class="text-muted mb-0">Cuenta el efectivo disponible y registra el monto final para completar el cierre.</p>
+                    </div>
+                    <div th:if="${cerrada}" class="alert alert-success" role="alert">
+                        <i class="bi bi-check-circle-fill me-2"></i>La caja se cerró correctamente.
+                    </div>
+                    <form th:if="${caja.estado} == T(cl.gob.binexus.domain.enums.EstadoCaja).ABIERTO"
+                          th:action="@{/caja/cerrar}" th:object="${form}" method="post" class="needs-validation" novalidate
+                          data-show-loader="true">
+                        <div class="mb-3">
+                            <label class="form-label" for="montoFinal">Monto contado</label>
+                            <div class="input-group">
+                                <span class="input-group-text">$</span>
+                                <input type="number" class="form-control" id="montoFinal" th:field="*{montoFinal}" step="0.01"
+                                       min="0" required aria-describedby="montoFinalHelp">
+                            </div>
+                            <small id="montoFinalHelp" class="form-text text-muted">Registra el total disponible en caja.</small>
+                            <div class="invalid-feedback" th:if="${#fields.hasErrors('montoFinal')}" th:errors="*{montoFinal}"></div>
+                        </div>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                        <div class="d-flex justify-content-end gap-2">
+                            <a class="btn btn-outline-secondary" th:href="@{/caja/abrir}"><i class="bi bi-door-open me-1"></i>Abrir nueva caja</a>
+                            <button type="submit" class="btn btn-danger">
+                                <i class="bi bi-lock-fill me-1"></i>Cerrar caja
+                            </button>
+                        </div>
+                    </form>
+                    <div th:if="${caja.estado} != T(cl.gob.binexus.domain.enums.EstadoCaja).ABIERTO">
+                        <p class="text-muted">No hay acciones disponibles porque la caja ya se encuentra cerrada.</p>
+                        <a class="btn btn-primary" th:href="@{/caja/historial}"><i class="bi bi-clock me-1"></i>Ver historial</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+</body>
+</html>

--- a/binexus-erp/src/main/resources/templates/cashbox/caja-historial.html
+++ b/binexus-erp/src/main/resources/templates/cashbox/caja-historial.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout" layout:decorate="~{layout}">
+<head>
+    <title>Historial de cajas</title>
+</head>
+<body>
+<section layout:fragment="content" class="col-lg-10 mx-auto">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h1 class="h3 fw-bold mb-1">Historial de cajas</h1>
+            <p class="text-muted mb-0">Consulta los movimientos de apertura y cierre asociados a tu usuario.</p>
+        </div>
+        <div class="btn-group" role="group" aria-label="Acciones de caja">
+            <a class="btn btn-outline-primary" th:href="@{/caja/abrir}"><i class="bi bi-door-open me-1"></i>Abrir</a>
+            <a class="btn btn-outline-success" th:href="@{/caja/cerrar}"><i class="bi bi-lock me-1"></i>Cerrar</a>
+        </div>
+    </div>
+    <div class="card border-0 shadow-sm">
+        <div class="table-responsive">
+            <table class="table table-hover align-middle mb-0">
+                <thead class="table-light">
+                <tr>
+                    <th scope="col">Estado</th>
+                    <th scope="col">Fecha apertura</th>
+                    <th scope="col">Fecha cierre</th>
+                    <th scope="col" class="text-end">Monto inicial</th>
+                    <th scope="col" class="text-end">Monto final</th>
+                    <th scope="col" class="text-end">Diferencia</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:if="${historial.empty}">
+                    <td colspan="6" class="text-center py-5 text-muted">No existen registros de cajas para este usuario.</td>
+                </tr>
+                <tr th:each="caja : ${historial}">
+                    <td>
+                        <span class="badge rounded-pill" th:classappend="${caja.estado.name() == 'ABIERTO'} ? ' bg-success-subtle text-success-emphasis' : ' bg-secondary-subtle text-secondary-emphasis'"
+                              th:text="${caja.estado}"></span>
+                    </td>
+                    <td th:text="${#temporals.format(caja.fechaApertura, 'dd/MM/yyyy HH:mm')}"></td>
+                    <td th:text="${caja.fechaCierre != null ? #temporals.format(caja.fechaCierre, 'dd/MM/yyyy HH:mm') : '-'}"></td>
+                    <td class="text-end" th:text="${#numbers.formatCurrency(caja.montoInicial)}"></td>
+                    <td class="text-end" th:text="${caja.montoFinal != null ? #numbers.formatCurrency(caja.montoFinal) : '-'}"></td>
+                    <td class="text-end" th:text="${resumenes[caja.id] != null ? #numbers.formatCurrency(resumenes[caja.id].diferencia) : '-'}"></td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>
+</body>
+</html>

--- a/binexus-erp/src/main/resources/templates/fragments/_sidebar.html
+++ b/binexus-erp/src/main/resources/templates/fragments/_sidebar.html
@@ -11,6 +11,12 @@
         <a class="list-group-item list-group-item-action" th:href="@{/dashboard}">
             <i class="bi bi-speedometer2 me-2"></i>Dashboard
         </a>
+        <a class="list-group-item list-group-item-action" th:href="@{/caja/cerrar}">
+            <i class="bi bi-cash-stack me-2"></i>Cierre de caja
+        </a>
+        <a class="list-group-item list-group-item-action" th:href="@{/autorizaciones}">
+            <i class="bi bi-shield-check me-2"></i>Autorizaciones remotas
+        </a>
         <sec:authorize access="hasRole('ADMIN')">
             <a class="list-group-item list-group-item-action" th:href="@{/admin/users}">
                 <i class="bi bi-people me-2"></i>Usuarios

--- a/binexus-erp/src/main/resources/templates/layout.html
+++ b/binexus-erp/src/main/resources/templates/layout.html
@@ -2,7 +2,8 @@
 <html lang="es" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head th:replace="fragments/_head :: head"></head>
-<body class="layout-body" th:attr="data-toast-success=${toastSuccess}">
+<body class="layout-body"
+      th:attr="data-toast-success=${toastSuccess},data-toast-error=${toastError},data-toast-info=${toastInfo}">
 <div class="d-flex" id="layout-wrapper">
     <aside th:replace="fragments/_sidebar :: sidebar"></aside>
     <div class="flex-grow-1 d-flex flex-column min-vh-100">
@@ -14,6 +15,12 @@
     </div>
 </div>
 <div id="toast-container" class="toast-container position-fixed top-0 end-0 p-3"></div>
+<div id="global-loader" class="d-none align-items-center justify-content-center">
+    <div class="text-center">
+        <div class="spinner-border text-primary" role="status" aria-hidden="true"></div>
+        <p class="mt-3 fw-semibold" role="status" aria-live="assertive">Procesando...</p>
+    </div>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>

--- a/binexus-erp/src/test/java/cl/gob/binexus/controller/AutorizacionRemotaControllerTest.java
+++ b/binexus-erp/src/test/java/cl/gob/binexus/controller/AutorizacionRemotaControllerTest.java
@@ -1,0 +1,108 @@
+package cl.gob.binexus.controller;
+
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoAutorizacion;
+import cl.gob.binexus.service.AutorizacionRemotaService;
+import cl.gob.binexus.service.CierreCajaService;
+import cl.gob.binexus.service.UsuarioService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = AutorizacionRemotaController.class)
+@AutoConfigureMockMvc
+class AutorizacionRemotaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AutorizacionRemotaService autorizacionRemotaService;
+
+    @MockBean
+    private CierreCajaService cierreCajaService;
+
+    @MockBean
+    private UsuarioService usuarioService;
+
+    private Usuario usuarioAutenticado() {
+        Usuario usuario = new Usuario();
+        usuario.setId(10L);
+        usuario.setNombre("Usuario Demo");
+        usuario.setCorreo("demo@binexus.cl");
+        return usuario;
+    }
+
+    @Test
+    @DisplayName("Solicitar autorización crea el registro cuando existe caja abierta")
+    void solicitarAutorizacionConCajaAbierta() throws Exception {
+        Usuario usuario = usuarioAutenticado();
+        CierreCaja caja = new CierreCaja();
+        caja.setId(4L);
+        caja.setFechaApertura(LocalDateTime.now().minusHours(1));
+
+        given(usuarioService.obtenerPorCorreo(usuario.getCorreo())).willReturn(usuario);
+        given(cierreCajaService.obtenerCajaAbierta(usuario)).willReturn(Optional.of(caja));
+
+        mockMvc.perform(post("/autorizaciones")
+                        .param("accion", "Modificar precio")
+                        .with(SecurityMockMvcRequestPostProcessors.user(usuario.getCorreo()))
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/autorizaciones"))
+                .andExpect(flash().attribute("toastSuccess", "Autorización solicitada correctamente"));
+
+        verify(autorizacionRemotaService).solicitar(usuario, caja, "Modificar precio");
+    }
+
+    @Test
+    @DisplayName("Solicitar autorización sin caja abierta muestra error")
+    void solicitarAutorizacionSinCaja() throws Exception {
+        Usuario usuario = usuarioAutenticado();
+        given(usuarioService.obtenerPorCorreo(usuario.getCorreo())).willReturn(usuario);
+        given(cierreCajaService.obtenerCajaAbierta(usuario)).willReturn(Optional.empty());
+
+        mockMvc.perform(post("/autorizaciones")
+                        .param("accion", "Anular venta")
+                        .with(SecurityMockMvcRequestPostProcessors.user(usuario.getCorreo()))
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("/autorizaciones"))
+                .andExpect(flash().attribute("toastError", "Debes abrir una caja para solicitar autorizaciones"));
+
+        Mockito.verifyNoInteractions(autorizacionRemotaService);
+    }
+
+    @Test
+    @DisplayName("Lista de autorizaciones incluye datos y estados")
+    void listarAutorizaciones() throws Exception {
+        Usuario usuario = usuarioAutenticado();
+        given(usuarioService.obtenerPorCorreo(usuario.getCorreo())).willReturn(usuario);
+        given(cierreCajaService.obtenerCajaAbierta(usuario)).willReturn(Optional.empty());
+        given(autorizacionRemotaService.listarPorEstado(null)).willReturn(List.of());
+
+        mockMvc.perform(get("/autorizaciones").with(SecurityMockMvcRequestPostProcessors.user(usuario.getCorreo())))
+                .andExpect(status().isOk())
+                .andExpect(model().attributeExists("autorizaciones"))
+                .andExpect(model().attribute("estadoSeleccionado", (EstadoAutorizacion) null))
+                .andExpect(view().name("authorizations/autorizaciones-list"));
+    }
+}

--- a/binexus-erp/src/test/java/cl/gob/binexus/service/CierreCajaServiceImplTest.java
+++ b/binexus-erp/src/test/java/cl/gob/binexus/service/CierreCajaServiceImplTest.java
@@ -1,0 +1,96 @@
+package cl.gob.binexus.service;
+
+import cl.gob.binexus.domain.entity.CierreCaja;
+import cl.gob.binexus.domain.entity.Usuario;
+import cl.gob.binexus.domain.enums.EstadoCaja;
+import cl.gob.binexus.dto.CierreCajaResumenDTO;
+import cl.gob.binexus.repository.CierreCajaRepository;
+import cl.gob.binexus.repository.VentaRepository;
+import cl.gob.binexus.service.impl.CierreCajaServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CierreCajaServiceImplTest {
+
+    @Mock
+    private CierreCajaRepository cierreCajaRepository;
+
+    @Mock
+    private VentaRepository ventaRepository;
+
+    @InjectMocks
+    private CierreCajaServiceImpl cierreCajaService;
+
+    private Usuario usuario;
+
+    @BeforeEach
+    void setUp() {
+        usuario = new Usuario();
+        usuario.setId(1L);
+    }
+
+    @Test
+    @DisplayName("No permite abrir una caja si ya existe una abierta para el usuario")
+    void abrirCajaConCajaExistenteLanzaExcepcion() {
+        when(cierreCajaRepository.existsByUsuarioAndEstado(usuario, EstadoCaja.ABIERTO)).thenReturn(true);
+
+        assertThrows(IllegalStateException.class, () -> cierreCajaService.abrirCaja(usuario, BigDecimal.TEN));
+        verify(cierreCajaRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Calcula correctamente el resumen del cierre de caja")
+    void generarResumenCalculaMontos() {
+        CierreCaja caja = new CierreCaja();
+        caja.setUsuario(usuario);
+        caja.setFechaApertura(LocalDateTime.now().minusHours(4));
+        caja.setFechaCierre(LocalDateTime.now());
+        caja.setMontoInicial(new BigDecimal("10000"));
+
+        when(ventaRepository.totalPorUsuarioYRango(eq(usuario), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(new BigDecimal("25000"));
+
+        CierreCajaResumenDTO resumen = cierreCajaService.generarResumen(caja, new BigDecimal("36000"));
+
+        assertEquals(new BigDecimal("10000"), resumen.getMontoInicial());
+        assertEquals(new BigDecimal("25000"), resumen.getTotalVentas());
+        assertEquals(new BigDecimal("35000"), resumen.getMontoFinalEsperado());
+        assertEquals(new BigDecimal("36000"), resumen.getMontoFinalDeclarado());
+        assertEquals(new BigDecimal("1000"), resumen.getDiferencia());
+    }
+
+    @Test
+    @DisplayName("Cierra la caja abierta actualizando estado y montos")
+    void cerrarCajaActualizaEstado() {
+        CierreCaja caja = new CierreCaja();
+        caja.setId(5L);
+        caja.setUsuario(usuario);
+        caja.setEstado(EstadoCaja.ABIERTO);
+        caja.setFechaApertura(LocalDateTime.now().minusHours(2));
+
+        when(cierreCajaRepository.findById(5L)).thenReturn(Optional.of(caja));
+        when(cierreCajaRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CierreCaja cerrada = cierreCajaService.cerrarCaja(caja, new BigDecimal("15000"));
+
+        assertEquals(EstadoCaja.CERRADO, cerrada.getEstado());
+        assertNotNull(cerrada.getFechaCierre());
+        assertEquals(new BigDecimal("15000"), cerrada.getMontoFinal());
+        verify(cierreCajaRepository).save(cerrada);
+    }
+}


### PR DESCRIPTION
## Resumen
- incorporar entidad y flujo completo de cierre de caja con vistas para abrir, cerrar e historial
- habilitar autorizaciones remotas ligadas a la caja abierta, con aprobación desde interfaz y controles de servicio
- añadir auditoría base para entidades, refinamientos visuales y cobertura de pruebas clave
- documentar guía rápida para la operación de caja y autorizaciones

## Pruebas
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e6669b0d1c8331937a8fd60ac693a9