### PR TITLE
Add H2 profile for local testing

### DIFF
--- a/binexus-erp/README.md
+++ b/binexus-erp/README.md
@@ -47,6 +47,17 @@ java -jar target/binexus-erp-0.0.1-SNAPSHOT.jar
 
 La aplicación quedará disponible en `http://localhost:8080`.
 
+### Ejecutar con base de datos H2 en memoria
+
+Si prefieres evitar instalar PostgreSQL para realizar pruebas locales rápidas, puedes iniciar la aplicación con el perfil `h2`,
+el cual levanta automáticamente una base de datos en memoria y ejecuta las migraciones Flyway sobre ella:
+
+```bash
+SPRING_PROFILES_ACTIVE=h2 mvn spring-boot:run
+```
+
+Al utilizar este perfil también se habilita la consola web de H2 en `http://localhost:8080/h2-console`, utilizando la URL `jdbc:h2:mem:binexus` y usuario `sa` (sin contraseña).
+
 ## Funcionalidades incluidas
 
 - Autenticación vía formulario (`/login`) con Spring Security y BCrypt.

--- a/binexus-erp/pom.xml
+++ b/binexus-erp/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <scope>test</scope>
+            <scope>runtime</scope>
         </dependency>
     </dependencies>
 

--- a/binexus-erp/src/main/resources/application-h2.yml
+++ b/binexus-erp/src/main/resources/application-h2.yml
@@ -1,0 +1,29 @@
+spring:
+  config:
+    activate:
+      on-profile: h2
+  datasource:
+    url: jdbc:h2:mem:binexus;MODE=PostgreSQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+    show-sql: false
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  main:
+    banner-mode: console
+
+logging:
+  level:
+    root: INFO


### PR DESCRIPTION
## Summary
- add an H2-specific Spring profile with in-memory database settings for quick local runs
- expose the H2 console and switch the database dependency to runtime scope
- document how to start the application against the in-memory database

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e6ad845eb48331ae9bbcda3cdbe385